### PR TITLE
drastically improved batch insertion into trees

### DIFF
--- a/src/main1.rs
+++ b/src/main1.rs
@@ -41,7 +41,7 @@ fn main() {
     //         .expect("Failed to add to WAL");
     // }
 
-    const NUM_VECTORS: usize = 1_000_000;
+    const NUM_VECTORS: usize = 100_000;
 
     let batch_vectors: Vec<Vec<[f32; VECTOR_SIZE]>> =
         (0..NUM_VECTORS).map(|_| vec![random_vec()]).collect();

--- a/src/services/commit.rs
+++ b/src/services/commit.rs
@@ -79,6 +79,8 @@ impl CommitService {
 
             // let mut metadata_index_items = Vec::new();
 
+            let mut batch_metadata_to_insert = Vec::new();
+
             for (idx, kv) in kvs.iter().enumerate() {
                 let metadata_index_item = MetadataIndexItem {
                     id: ids[idx],
@@ -87,13 +89,13 @@ impl CommitService {
                     // namespaced_id: self.state.namespace_id.clone(),
                 };
 
-                println!("Inserting id: {},  {} of {}", ids[idx], idx, ids.len());
+                // println!("Inserting id: {},  {} of {}", ids[idx], idx, ids.len());
 
-                // metadata_index_items.push((ids[idx], metadata_index_item));
+                batch_metadata_to_insert.push((ids[idx], metadata_index_item));
 
-                self.state
-                    .metadata_index
-                    .insert(ids[idx], metadata_index_item);
+                // self.state
+                //     .metadata_index
+                //     .insert(ids[idx], metadata_index_item);
 
                 for kv in kv {
                     // let inverted_index_item = InvertedIndexItem {
@@ -111,6 +113,10 @@ impl CommitService {
                         .push((vector_indices[idx], ids[idx]));
                 }
             }
+
+            self.state
+                .metadata_index
+                .batch_insert(batch_metadata_to_insert);
 
             // self.state.metadata_index.batch_insert(metadata_index_items);
 

--- a/src/services/query.rs
+++ b/src/services/query.rs
@@ -54,7 +54,7 @@ impl QueryService {
             }
         }
 
-        println!("INDICES: {:?}", indices.len());
+        // println!("INDICES: {:?}", indices.len());
 
         // let mut top_k_indices = Vec::with_capacity(top_k);
 

--- a/src/structures/mmap_tree/node.rs
+++ b/src/structures/mmap_tree/node.rs
@@ -8,7 +8,7 @@ pub enum NodeType {
     Internal,
 }
 
-const MAX_KEYS: usize = 1024;
+const MAX_KEYS: usize = 32;
 
 pub fn serialize_node_type(node_type: &NodeType) -> [u8; 1] {
     match node_type {
@@ -92,7 +92,7 @@ where
                     node_type: NodeType::Internal,
                     offset: 0, // This should be set when the node is stored
                     is_root: false,
-                    parent_offset: Some(0),
+                    parent_offset: self.parent_offset,
                 };
 
                 // println!(
@@ -120,7 +120,7 @@ where
                     node_type: NodeType::Leaf,
                     offset: 0, // This should be set when the node is stored
                     is_root: false,
-                    parent_offset: Some(0),
+                    parent_offset: self.parent_offset,
                 };
 
                 // println!(

--- a/tests/trees.rs
+++ b/tests/trees.rs
@@ -336,4 +336,45 @@ mod tests {
         assert_eq!(tree.search(min_int).unwrap(), Some("minimum".to_string()));
         assert_eq!(tree.search(max_int).unwrap(), Some("maximum".to_string()));
     }
+
+    #[test]
+    fn test_batch_insert() {
+        let path = PathBuf::from_str("tests/data")
+            .unwrap()
+            .join(uuid::Uuid::new_v4().to_string())
+            .join("test.bin");
+        fs::create_dir_all(&path.parent().unwrap()).expect("Failed to create directory");
+
+        let mut tree: Tree<i32, String> = Tree::new(path).expect("Failed to create tree");
+
+        const NUM_ITEMS: usize = 10_000;
+
+        for i in 0..NUM_ITEMS {
+            tree.insert(i as i32, format!("value_{}", i))
+                .expect(format!("Failed to insert {}", i).as_str());
+        }
+
+        for i in 0..NUM_ITEMS {
+            assert_eq!(tree.search(i as i32).unwrap(), Some(format!("value_{}", i)));
+        }
+
+        let path = PathBuf::from_str("tests/data")
+            .unwrap()
+            .join(uuid::Uuid::new_v4().to_string())
+            .join("test.bin");
+
+        fs::create_dir_all(&path.parent().unwrap()).expect("Failed to create directory");
+
+        let mut tree: Tree<i32, String> = Tree::new(path).expect("Failed to create tree");
+
+        let entries: Vec<(i32, String)> = (0..NUM_ITEMS)
+            .map(|i| (i as i32, format!("value_{}", i)))
+            .collect();
+
+        tree.batch_insert(entries).expect("Failed to batch insert");
+
+        for i in 0..NUM_ITEMS {
+            assert_eq!(tree.search(i as i32).unwrap(), Some(format!("value_{}", i)));
+        }
+    }
 }


### PR DESCRIPTION
This will significantly speed up large commits, like when you're doing a bunch of  `/addVector`s